### PR TITLE
Follow up PR #3 with cleanup and zmodem hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,24 @@ networking client.  The code is intended to be self‑contained, dependency‑fr
 
 * The project follows **PEP 8** style; run `black`/`autopep8` or `flake8` in the
   virtualenv before committing.  A `requirements-dev.txt` is provided for
-the linter and test runner.
-* Use `pytest` (with `pytest-asyncio`) to execute the tests.  Example:
+  the linter and test runner.
+* Use `pytest` (with `pytest-asyncio`) to execute the tests. The test harness
+  used in CI also relies on `pytest-timeout` to prevent hanging tests; it's
+  included in `requirements-dev.txt`.
+
+Running tests (recommended workflow):
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements-dev.txt
+pytest -v
+```
+
+If tests hang locally, `pytest-timeout` enforces per-test time limits; you can
+adjust timeouts via `--timeout=<seconds>` when invoking `pytest`.
+
 
 ```bash
 python -m venv .venv

--- a/README.md
+++ b/README.md
@@ -1,4 +1,26 @@
 # Akita-Zmodem-MeshCore
+This repository contains a **Python implementation of a lightweight ZMODEM-like
+file transfer protocol** that is tightly integrated with the MeshCore mesh
+networking client.  The code is intended to be self‑contained, dependency‑free
+(other than MeshCore when used), and covered by an extensive unit test suite.
+
+## Development notes
+
+* The project follows **PEP 8** style; run `black`/`autopep8` or `flake8` in the
+  virtualenv before committing.  A `requirements-dev.txt` is provided for
+the linter and test runner.
+* Use `pytest` (with `pytest-asyncio`) to execute the tests.  Example:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-dev.txt
+pytest -q
+```
+
+* All lint warnings have been cleared; contributions should remain free of
+  `E722`/`E701`/unused-imports etc.  `autopep8 --in-place` is handy for
+  bulk fixes.
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 

--- a/akita_zmodem_meshcore.py
+++ b/akita_zmodem_meshcore.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
+import tempfile
+import atexit
+import zmodem
 import asyncio
 import logging
 import os
 import zipfile
-import io
 import argparse
 import json
 import time
@@ -15,6 +17,8 @@ import hashlib
 # -----------------------------------------------------------------------------
 # Dependency Validation
 # -----------------------------------------------------------------------------
+
+
 def check_dependency(module_name, pip_name):
     try:
         __import__(module_name)
@@ -23,6 +27,7 @@ def check_dependency(module_name, pip_name):
         print(f"Please install it: pip install {pip_name}")
         sys.exit(1)
 
+
 # Attempt to import MeshCore; allow module import even if the dependency
 # is not installed so tests and documentation can be generated.  If missing
 # the concrete `_connect_mesh` call will fail at runtime with a clear error.
@@ -30,16 +35,15 @@ try:
     from meshcore import MeshCore, EventType
 except Exception:
     MeshCore = None
+
     class EventType:
         CONTACT_MSG_RECV = "contact_msg_recv"
         ERROR = "error"
 
-import zmodem
-import atexit
-import tempfile
 
 # global list for any temp zips created by any instance; cleaned at exit
 _temp_zip_files = []
+
 
 def _cleanup_temp_zips():
     for fp in list(_temp_zip_files):
@@ -49,11 +53,13 @@ def _cleanup_temp_zips():
         except Exception:
             pass
 
+
 atexit.register(_cleanup_temp_zips)
 
 
 class UnsafeZipError(Exception):
     """Raised when a zip archive contains unsafe member paths (ZipSlip)."""
+
 
 # Optional: TQDM for progress bars
 try:
@@ -62,7 +68,9 @@ try:
 except Exception:
     TQDM_AVAILABLE = False
     try:
-        print("Suggestion: Install 'tqdm' for progress bars (pip install tqdm)", file=sys.stderr)
+        print(
+            "Suggestion: Install 'tqdm' for progress bars (pip install tqdm)",
+            file=sys.stderr)
     except Exception:
         pass
 
@@ -76,7 +84,8 @@ DEFAULT_CONFIG = {
     # current implementation; some third‑party zmodem wrappers expose a
     # chunk size parameter so we keep the value here for compatibility.
     "chunk_size": 256,             # Internal Zmodem buffer size (unused)
-    "mesh_packet_chunk_size": 200, # Max payload per mesh packet (LoRa MTU safe)
+    # Max payload per mesh packet (LoRa MTU safe)
+    "mesh_packet_chunk_size": 200,
     "timeout": 120,                # Extended timeout for slow links
     "mesh_connection_type": "serial",
     "mesh_serial_port": "/dev/ttyUSB0",
@@ -86,7 +95,7 @@ DEFAULT_CONFIG = {
     "tx_delay_ms": 150             # Throttle to prevent radio buffer saturation
 }
 
-APP_PORT_HEADER_FORMAT = "!H" 
+APP_PORT_HEADER_FORMAT = "!H"
 APP_PORT_HEADER_SIZE = struct.calcsize(APP_PORT_HEADER_FORMAT)
 
 # -----------------------------------------------------------------------------
@@ -101,6 +110,8 @@ logging.basicConfig(
 # -----------------------------------------------------------------------------
 # Helpers
 # -----------------------------------------------------------------------------
+
+
 def load_config(config_file: str = None):
     """Return configuration dictionary from the given JSON file.
 
@@ -127,6 +138,7 @@ def load_config(config_file: str = None):
             pass
         return DEFAULT_CONFIG
 
+
 # The constants below are populated lazily from the first instance so that
 # CLI overrides (and alternate config file paths) work correctly.  They remain
 # here primarily for backward compatibility with external code or tests that
@@ -136,6 +148,7 @@ ZMODEM_APP_PORT = None
 MESH_PACKET_CHUNK_SIZE = None
 TIMEOUT = None
 TX_DELAY_S = None
+
 
 def calculate_md5(filepath):
     """Calculates MD5 checksum of a file for integrity verification.
@@ -157,7 +170,8 @@ def _safe_extract_zip(zip_path, extract_to):
     Streams entry names to avoid loading an entire name list into memory.
     Raises an Exception if any member would extract outside `extract_to`.
     """
-    import zipfile, os
+    import zipfile
+    import os
 
     with zipfile.ZipFile(zip_path, 'r') as z:
         for info in z.infolist():
@@ -168,8 +182,11 @@ def _safe_extract_zip(zip_path, extract_to):
             dest_path = os.path.join(extract_to, normalized)
             abs_dest = os.path.abspath(dest_path)
             abs_base = os.path.abspath(extract_to)
-            if not (abs_dest == abs_base or abs_dest.startswith(abs_base + os.sep)):
-                raise UnsafeZipError(f"Zip would extract outside target: {member}")
+            if not (
+                abs_dest == abs_base or abs_dest.startswith(
+                    abs_base + os.sep)):
+                raise UnsafeZipError(
+                    f"Zip would extract outside target: {member}")
             # Ensure directory exists
             parent = os.path.dirname(abs_dest)
             if parent and not os.path.exists(parent):
@@ -185,6 +202,8 @@ def _safe_extract_zip(zip_path, extract_to):
 # -----------------------------------------------------------------------------
 # Core Class
 # -----------------------------------------------------------------------------
+
+
 class AkitaZmodemMeshCore:
     def __init__(self, cli_config_overrides=None, config_file: str = None):
         self.mesh = None
@@ -194,6 +213,7 @@ class AkitaZmodemMeshCore:
         self._mesh_receive_queue = asyncio.Queue()
         self._temp_zips = []  # track temp archives for cleanup
         # register instance temp files in global list for atexit cleanup
+
         def _register(fp):
             _temp_zip_files.append(fp)
         self._register_temp = _register
@@ -205,10 +225,14 @@ class AkitaZmodemMeshCore:
         self._validate_config()
 
         # compute frequently-used values once per instance
-        self.zmodem_app_port = self.app_config.get("zmodem_app_port", DEFAULT_CONFIG["zmodem_app_port"])
-        self.mesh_packet_chunk_size = self.app_config.get("mesh_packet_chunk_size", DEFAULT_CONFIG["mesh_packet_chunk_size"])
-        self.timeout = self.app_config.get("timeout", DEFAULT_CONFIG["timeout"])
-        self.tx_delay_s = self.app_config.get("tx_delay_ms", DEFAULT_CONFIG["tx_delay_ms"]) / 1000.0
+        self.zmodem_app_port = self.app_config.get(
+            "zmodem_app_port", DEFAULT_CONFIG["zmodem_app_port"])
+        self.mesh_packet_chunk_size = self.app_config.get(
+            "mesh_packet_chunk_size", DEFAULT_CONFIG["mesh_packet_chunk_size"])
+        self.timeout = self.app_config.get(
+            "timeout", DEFAULT_CONFIG["timeout"])
+        self.tx_delay_s = self.app_config.get(
+            "tx_delay_ms", DEFAULT_CONFIG["tx_delay_ms"]) / 1000.0
 
         # update module globals so tests relying on them remain valid
         global config_data, ZMODEM_APP_PORT, MESH_PACKET_CHUNK_SIZE, TIMEOUT, TX_DELAY_S
@@ -233,8 +257,11 @@ class AkitaZmodemMeshCore:
         for key, typ in fields:
             val = self.app_config.get(key)
             if val is not None and not isinstance(val, typ):
-                raise ValueError(f"Configuration key '{key}' must be {typ}, got {type(val)}")
-            if key in ("mesh_packet_chunk_size", "timeout") and val is not None:
+                raise ValueError(
+                    f"Configuration key '{key}' must be {typ}, got {type(val)}")
+            if key in (
+                "mesh_packet_chunk_size",
+                    "timeout") and val is not None:
                 if val <= 0:
                     raise ValueError(f"{key} must be positive")
 
@@ -244,7 +271,9 @@ class AkitaZmodemMeshCore:
         # is not available. The module import is optional for documentation
         # and testing, but actual operation requires the client.
         if MeshCore is None:
-            raise RuntimeError("MeshCore Python client is not installed; install via 'pip install meshcore' or provide a compatible library.")
+            raise RuntimeError(
+                "MeshCore Python client is not installed; install via 'pip install meshcore' "
+                "or provide a compatible library.")
         try:
             if conn_type == "serial":
                 port = self.app_config.get("mesh_serial_port")
@@ -256,10 +285,12 @@ class AkitaZmodemMeshCore:
                 port = self.app_config.get("mesh_tcp_port")
                 logging.info(f"Connecting TCP: {host}:{port}")
                 self.mesh = await MeshCore.create_tcp(host=host, port=port)
-            
+
             if self.mesh:
                 logging.info("Connected to MeshCore Network.")
-                self.mesh.subscribe(EventType.CONTACT_MSG_RECV, self._on_mesh_message)
+                self.mesh.subscribe(
+                    EventType.CONTACT_MSG_RECV,
+                    self._on_mesh_message)
                 self.mesh.subscribe(EventType.ERROR, self._on_mesh_error)
                 return True
         except Exception as e:
@@ -271,13 +302,15 @@ class AkitaZmodemMeshCore:
             payload = event.payload
             # Extract Source ID (compatible with multiple lib versions)
             src = str(payload.get('from_num', payload.get('from', 'unknown')))
-            
+
             # Extract Data (decoded payload or raw text fallback)
             data = payload.get('decoded', {}).get('payload')
             if not data:
                 txt = payload.get('text')
-                if isinstance(txt, str): data = txt.encode('utf-8', 'ignore')
-                elif isinstance(txt, bytes): data = txt
+                if isinstance(txt, str):
+                    data = txt.encode('utf-8', 'ignore')
+                elif isinstance(txt, bytes):
+                    data = txt
 
             if data and isinstance(data, bytes):
                 await self._mesh_receive_queue.put({"source": src, "data": data})
@@ -285,47 +318,61 @@ class AkitaZmodemMeshCore:
             logging.error(f"Msg Parse Error: {e}")
 
     async def _on_mesh_error(self, event):
-        logging.warning(f"Mesh Error: {event.payload if hasattr(event, 'payload') else event}")
+        logging.warning(
+            f"Mesh Error: {
+                event.payload if hasattr(
+                    event,
+                    'payload') else event}")
 
     # -------------------------------------------------------------------------
     # Send Logic
     # -------------------------------------------------------------------------
     async def send_file(self, dest_node, filepath, cli_event=None):
         if not self.mesh:
-            if cli_event: cli_event.set()
+            if cli_event:
+                cli_event.set()
             return None
         if os.path.isdir(filepath):
             logging.error(f"Path '{filepath}' is a directory, not a file")
-            if cli_event: cli_event.set()
+            if cli_event:
+                cli_event.set()
             return None
         if not isinstance(dest_node, str) or not dest_node:
             logging.error(f"Invalid destination node: {dest_node}")
-            if cli_event: cli_event.set()
+            if cli_event:
+                cli_event.set()
             return None
 
         if not os.path.exists(filepath):
             logging.error(f"File not found: {filepath}")
-            if cli_event: cli_event.set()
+            if cli_event:
+                cli_event.set()
             return None
 
         tid = self.generate_transfer_id()
         fsize = os.path.getsize(filepath)
         # calculate checksum in a thread to avoid blocking the event loop
         checksum = await asyncio.to_thread(calculate_md5, filepath)
-        
-        logging.info(f"[Tx-{tid}] File: {os.path.basename(filepath)} | Size: {fsize:,} bytes | MD5: {checksum}")
+
+        logging.info(
+            f"[Tx-{tid}] File: {
+                os.path.basename(filepath)} | Size: {
+                fsize:,} bytes | MD5: {checksum}")
 
         try:
             # Open file in thread to avoid blocking loop
             sync_f = await asyncio.to_thread(open, filepath, "rb")
             # let the sender know the configured chunk size (legacy key
             # "chunk_size", kept for compatibility)
-            sz = self.app_config.get("chunk_size", DEFAULT_CONFIG["chunk_size"])
+            sz = self.app_config.get(
+                "chunk_size", DEFAULT_CONFIG["chunk_size"])
             sender = await asyncio.to_thread(zmodem.Sender, sync_f, sz)
         except Exception as e:
             logging.error(f"Zmodem Init Error: {e}")
-            if 'sync_f' in locals() and sync_f: sync_f.close()
-            if cli_event: cli_event.set()
+            if 'sync_f' in locals() and sync_f:
+                sync_f.close()
+            if cli_event:
+                cli_event.set()
             return None
 
         self.transfers[tid] = {
@@ -342,11 +389,16 @@ class AkitaZmodemMeshCore:
         t = self.transfers[tid]
         sender = t["sender"]
         dest = t["dest"]
-        
+
         # Progress Bar
         pbar = None
         if TQDM_AVAILABLE:
-            pbar = tqdm(total=t["total"], desc=f"Tx-{tid}", unit="B", unit_scale=True, leave=True)
+            pbar = tqdm(
+                total=t["total"],
+                desc=f"Tx-{tid}",
+                unit="B",
+                unit_scale=True,
+                leave=True)
 
         try:
             while self.running:
@@ -358,9 +410,11 @@ class AkitaZmodemMeshCore:
                 packet = await asyncio.to_thread(sender.get_next_packet)
 
                 if packet:
-                    logging.debug(f"[Tx-{tid}] next packet size {len(packet)} state={sender.state}")
+                    logging.debug(
+                        f"[Tx-{tid}] next packet size {len(packet)} state={sender.state}")
                     # Construct ZMODEM packet once (packet includes framing)
-                    header = struct.pack(APP_PORT_HEADER_FORMAT, self.zmodem_app_port)
+                    header = struct.pack(
+                        APP_PORT_HEADER_FORMAT, self.zmodem_app_port)
                     remaining = packet
 
                     # Chunking: ensure each chunk begins with header so receiver can
@@ -373,23 +427,26 @@ class AkitaZmodemMeshCore:
                         remaining = remaining[len(piece):]
                         chunk = header + piece
                         try:
-                            logging.debug(f"[Tx-{tid}] sending chunk {len(chunk)}")
+                            logging.debug(
+                                f"[Tx-{tid}] sending chunk {len(chunk)}")
                             await self.mesh.commands.send_msg(destination=dest, payload=chunk)
                             t["last_act"] = time.time()
                             # Throttle
                             await asyncio.sleep(self.tx_delay_s)
                         except Exception as e:
                             logging.warning(f"[Tx-{tid}] Send Fail: {e}")
-                            await asyncio.sleep(1.0) # Backoff
-                    
-                    if pbar: pbar.update(len(packet))
+                            await asyncio.sleep(1.0)  # Backoff
+
+                    if pbar:
+                        pbar.update(len(packet))
                 else:
                     await asyncio.sleep(0.1)
 
         except Exception as e:
             logging.error(f"[Tx-{tid}] Error: {e}")
         finally:
-            if pbar: pbar.close()
+            if pbar:
+                pbar.close()
             self.cancel_transfer(tid)
 
     # -------------------------------------------------------------------------
@@ -398,7 +455,8 @@ class AkitaZmodemMeshCore:
     async def receive_file(self, filepath, overwrite=False, cli_event=None):
         if os.path.exists(filepath) and not overwrite:
             logging.error(f"File exists: {filepath} (Use --overwrite)")
-            if cli_event: cli_event.set()
+            if cli_event:
+                cli_event.set()
             return None
 
         tid = self.generate_transfer_id()
@@ -419,15 +477,19 @@ class AkitaZmodemMeshCore:
                 src = item["source"]
                 data = item["data"]
 
-                if len(data) <= APP_PORT_HEADER_SIZE: continue
+                if len(data) <= APP_PORT_HEADER_SIZE:
+                    continue
 
-                port = struct.unpack(APP_PORT_HEADER_FORMAT, data[:APP_PORT_HEADER_SIZE])[0]
+                port = struct.unpack(APP_PORT_HEADER_FORMAT,
+                                     data[:APP_PORT_HEADER_SIZE])[0]
                 if port == self.zmodem_app_port:
                     # strip header and deliver to protocol handler
                     await self._handle_zmodem_data(src, data[APP_PORT_HEADER_SIZE:])
-                
-            except asyncio.TimeoutError: pass
-            except Exception as e: logging.error(f"Listener Error: {e}")
+
+            except asyncio.TimeoutError:
+                pass
+            except Exception as e:
+                logging.error(f"Listener Error: {e}")
 
     async def _handle_zmodem_data(self, src, data):
         active_tid = None
@@ -443,7 +505,8 @@ class AkitaZmodemMeshCore:
                 try:
                     t["receiver"] = await asyncio.to_thread(zmodem.Receiver, t["file"])
                 except Exception as e:
-                    logging.error(f"[Rx-{tid}] Cannot init receiver for '{t['file']}': {e}")
+                    logging.error(
+                        f"[Rx-{tid}] Cannot init receiver for '{t['file']}': {e}")
                     self.cancel_transfer(tid)
                     continue
                 logging.info(f"[Rx-{tid}] Incoming stream from {src} accepted")
@@ -463,20 +526,27 @@ class AkitaZmodemMeshCore:
         if t["state"] == "receiving":
             receiver = t["receiver"]
             try:
-                logging.debug(f"[Rx-{active_tid}] delivering {len(data)} bytes to receiver")
+                logging.debug(
+                    f"[Rx-{active_tid}] delivering {len(data)} bytes to receiver")
                 resp = await asyncio.to_thread(receiver.receive, data)
                 t["bytes"] += len(data)
-                logging.debug(f"[Rx-{active_tid}] receiver state={receiver.state} resp_len={len(resp) if resp else 0}")
+                logging.debug(
+                    f"[Rx-{active_tid}] receiver state={
+                        receiver.state} resp_len={
+                        len(resp) if resp else 0}")
 
                 if resp:
-                    resp_payload = struct.pack(APP_PORT_HEADER_FORMAT, self.zmodem_app_port) + resp
-                    logging.debug(f"[Rx-{active_tid}] sending {len(resp)} bytes back")
+                    resp_payload = struct.pack(
+                        APP_PORT_HEADER_FORMAT, self.zmodem_app_port) + resp
+                    logging.debug(
+                        f"[Rx-{active_tid}] sending {len(resp)} bytes back")
                     await self.mesh.commands.send_msg(destination=src, payload=resp_payload)
 
                 if await asyncio.to_thread(receiver.is_finished):
                     logging.info(f"[Rx-{active_tid}] Transfer Complete.")
                     checksum = await asyncio.to_thread(calculate_md5, t["file"])
-                    logging.info(f"[Rx-{active_tid}] File Saved. MD5: {checksum}")
+                    logging.info(
+                        f"[Rx-{active_tid}] File Saved. MD5: {checksum}")
                     self.cancel_transfer(active_tid)
             except Exception as e:
                 logging.error(f"[Rx-{active_tid}] Zmodem Protocol Error: {e}")
@@ -484,17 +554,21 @@ class AkitaZmodemMeshCore:
 
         elif t["state"] == "sending" and t.get("sender"):
             try:
-                logging.debug(f"[Tx-{active_tid}] delivering {len(data)} bytes to sender")
+                logging.debug(
+                    f"[Tx-{active_tid}] delivering {len(data)} bytes to sender")
                 resp = await asyncio.to_thread(t["sender"].receive, data)
-                logging.debug(f"[Tx-{active_tid}] sender returned {len(resp) if resp else 0} bytes")
+                logging.debug(
+                    f"[Tx-{active_tid}] sender returned {len(resp) if resp else 0} bytes")
                 if resp:
-                    resp_payload = struct.pack(APP_PORT_HEADER_FORMAT, self.zmodem_app_port) + resp
+                    resp_payload = struct.pack(
+                        APP_PORT_HEADER_FORMAT, self.zmodem_app_port) + resp
                     await self.mesh.commands.send_msg(destination=src, payload=resp_payload)
             except Exception as e:
                 logging.error(f"[Tx-{active_tid}] Protocol error: {e}")
     # -------------------------------------------------------------------------
     # Directory Handling & Management
     # -------------------------------------------------------------------------
+
     async def send_directory(self, dest, path, cli_event, cleanup=True):
         # create temporary zip file in system temp directory to avoid cluttering
         # the working directory; the file is deleted when the transfer finishes
@@ -510,9 +584,11 @@ class AkitaZmodemMeshCore:
                 for root, _, files in os.walk(path):
                     for file in files:
                         p = os.path.join(root, file)
-                        # skip symlinks to avoid unintentionally archiving system paths
+                        # skip symlinks to avoid unintentionally archiving
+                        # system paths
                         if os.path.islink(p):
-                            logging.debug(f"Skipping symlink {p} in directory transfer")
+                            logging.debug(
+                                f"Skipping symlink {p} in directory transfer")
                             continue
                         z.write(p, os.path.relpath(p, path))
 
@@ -543,18 +619,27 @@ class AkitaZmodemMeshCore:
                     if os.path.exists(zip_name):
                         os.remove(zip_name)
                 except Exception as e:
-                    logging.warning(f"Failed to remove temp zip '{zip_name}': {e}")
+                    logging.warning(
+                        f"Failed to remove temp zip '{zip_name}': {e}")
             if cli_event:
-                try: cli_event.set()
-                except Exception: pass
+                try:
+                    cli_event.set()
+                except Exception:
+                    pass
 
-    async def receive_directory(self, path, overwrite, cli_event, cleanup=True):
-        if not os.path.exists(path): os.makedirs(path)
+    async def receive_directory(
+            self,
+            path,
+            overwrite,
+            cli_event,
+            cleanup=True):
+        if not os.path.exists(path):
+            os.makedirs(path)
         # create a secure temporary file for the incoming zip to avoid
         # predictable filenames and TOCTOU issues
         with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tf:
             zip_name = tf.name
-        
+
         f_event = asyncio.Event()
         tid = await self.receive_file(zip_name, overwrite, f_event)
         if tid:
@@ -568,12 +653,16 @@ class AkitaZmodemMeshCore:
                 except UnsafeZipError as e:
                     logging.error(f"Received zip rejected as unsafe: {e}")
                 except Exception as e:
-                    logging.error(f"Failed to extract received zip '{zip_name}': {e}")
+                    logging.error(
+                        f"Failed to extract received zip '{zip_name}': {e}")
                 finally:
                     if cleanup:
-                        try: os.remove(zip_name)
-                        except: pass
-        if cli_event: cli_event.set()
+                        try:
+                            os.remove(zip_name)
+                        except BaseException:
+                            pass
+        if cli_event:
+            cli_event.set()
 
     def cancel_transfer(self, tid):
         if tid in self.transfers:
@@ -590,8 +679,10 @@ class AkitaZmodemMeshCore:
                         # schedule a threaded close
                         asyncio.create_task(asyncio.to_thread(f.close))
                     else:
-                        try: f.close()
-                        except Exception: pass
+                        try:
+                            f.close()
+                        except Exception:
+                            pass
                 except Exception:
                     pass
             # If receiver exists and holds an open file, close that safely
@@ -606,15 +697,18 @@ class AkitaZmodemMeshCore:
                             except RuntimeError:
                                 loop = None
                             if loop and loop.is_running():
-                                asyncio.create_task(asyncio.to_thread(rcv.fobj.close))
+                                asyncio.create_task(
+                                    asyncio.to_thread(rcv.fobj.close))
                             else:
-                                try: rcv.fobj.close()
-                                except Exception: pass
+                                try:
+                                    rcv.fobj.close()
+                                except Exception:
+                                    pass
                         except Exception:
                             pass
                 except Exception:
                     pass
-            if t.get("cli_event"): 
+            if t.get("cli_event"):
                 t["cli_event"].set()
             return True
         return False
@@ -630,33 +724,42 @@ class AkitaZmodemMeshCore:
 
     async def stop(self):
         self.running = False
-        for tid in list(self.transfers.keys()): self.cancel_transfer(tid)
-        if self.mesh: 
-            try: await self.mesh.close()
-            except: pass
+        for tid in list(self.transfers.keys()):
+            self.cancel_transfer(tid)
+        if self.mesh:
+            try:
+                await self.mesh.close()
+            except BaseException:
+                pass
 
 # -----------------------------------------------------------------------------
 # CLI Entry Point
 # -----------------------------------------------------------------------------
+
+
 async def main():
     parser = argparse.ArgumentParser(description="Akita-Zmodem-MeshCore")
-    parser.add_argument("--config", default=CONFIG_FILE,
-                        help="Path to configuration JSON file (will be created if missing)")
+    parser.add_argument(
+        "--config",
+        default=CONFIG_FILE,
+        help="Path to configuration JSON file (will be created if missing)")
     parser.add_argument("--mesh-type", choices=["serial", "tcp"],
                         help="Override the connection type from config")
-    parser.add_argument("--serial-port", help="Serial device path (for serial)")
+    parser.add_argument(
+        "--serial-port",
+        help="Serial device path (for serial)")
     parser.add_argument("--serial-baud", type=int, help="Serial baud rate")
     parser.add_argument("--tcp-host", dest="tcp_host",
                         help="TCP host for meshcore connection (tcp)")
     parser.add_argument("--tcp-port", dest="tcp_port", type=int,
                         help="TCP port for meshcore connection (tcp)")
-    
+
     sub = parser.add_subparsers(dest="command")
-    
+
     p_send = sub.add_parser("send")
     p_send.add_argument("dest", help="Dest Node ID")
     p_send.add_argument("path", help="File/Dir path")
-    
+
     p_recv = sub.add_parser("receive")
     p_recv.add_argument("path", help="Save path (directory or filename)")
     p_recv.add_argument("--overwrite", action="store_true")
@@ -686,8 +789,10 @@ async def main():
     def sig_handler():
         logging.info("Interrupted. Stopping...")
         asyncio.create_task(app.stop())
-    try: asyncio.get_running_loop().add_signal_handler(signal.SIGINT, sig_handler)
-    except: pass
+    try:
+        asyncio.get_running_loop().add_signal_handler(signal.SIGINT, sig_handler)
+    except BaseException:
+        pass
 
     try:
         if not await app._connect_mesh():
@@ -712,7 +817,11 @@ async def main():
             await cli_event.wait()
 
         elif args.command == "receive":
-            is_dir = getattr(args, "directory", False) or os.path.isdir(args.path)
+            is_dir = getattr(
+                args,
+                "directory",
+                False) or os.path.isdir(
+                args.path)
             if is_dir:
                 await app.receive_directory(args.path, args.overwrite, cli_event)
             else:
@@ -721,7 +830,7 @@ async def main():
 
         elif args.command == "status":
             print(json.dumps(app.transfers, default=str, indent=2))
-        
+
         elif args.command == "cancel":
             app.cancel_transfer(args.id)
 
@@ -731,9 +840,13 @@ async def main():
             while app.running:
                 await asyncio.sleep(1)
 
-    except asyncio.CancelledError: pass
-    finally: await app.stop()
+    except asyncio.CancelledError:
+        pass
+    finally:
+        await app.stop()
 
 if __name__ == "__main__":
-    try: asyncio.run(main())
-    except KeyboardInterrupt: pass
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/akita_zmodem_meshcore.py
+++ b/akita_zmodem_meshcore.py
@@ -304,7 +304,7 @@ class AkitaZmodemMeshCore:
             src = str(payload.get('from_num', payload.get('from', 'unknown')))
 
             # Extract Data (decoded payload or raw text fallback)
-            data = payload.get('decoded', {}).get('payload')
+            data = (payload.get('decoded') or {}).get('payload')
             if not data:
                 txt = payload.get('text')
                 if isinstance(txt, str):
@@ -318,11 +318,8 @@ class AkitaZmodemMeshCore:
             logging.error(f"Msg Parse Error: {e}")
 
     async def _on_mesh_error(self, event):
-        logging.warning(
-            f"Mesh Error: {
-                event.payload if hasattr(
-                    event,
-                    'payload') else event}")
+        msg = event.payload if hasattr(event, 'payload') else event
+        logging.warning(f"Mesh Error: {msg}")
 
     # -------------------------------------------------------------------------
     # Send Logic
@@ -353,11 +350,10 @@ class AkitaZmodemMeshCore:
         fsize = os.path.getsize(filepath)
         # calculate checksum in a thread to avoid blocking the event loop
         checksum = await asyncio.to_thread(calculate_md5, filepath)
+        fname = os.path.basename(filepath)
 
         logging.info(
-            f"[Tx-{tid}] File: {
-                os.path.basename(filepath)} | Size: {
-                fsize:,} bytes | MD5: {checksum}")
+            f"[Tx-{tid}] File: {fname} | Size: {fsize:,} bytes | MD5: {checksum}")
 
         try:
             # Open file in thread to avoid blocking loop
@@ -530,10 +526,10 @@ class AkitaZmodemMeshCore:
                     f"[Rx-{active_tid}] delivering {len(data)} bytes to receiver")
                 resp = await asyncio.to_thread(receiver.receive, data)
                 t["bytes"] += len(data)
+                resp_len = len(resp) if resp else 0
+                receiver_state = getattr(receiver, 'state', 'unknown')
                 logging.debug(
-                    f"[Rx-{active_tid}] receiver state={
-                        receiver.state} resp_len={
-                        len(resp) if resp else 0}")
+                    f"[Rx-{active_tid}] receiver state={receiver_state} resp_len={resp_len}")
 
                 if resp:
                     resp_payload = struct.pack(
@@ -659,7 +655,7 @@ class AkitaZmodemMeshCore:
                     if cleanup:
                         try:
                             os.remove(zip_name)
-                        except BaseException:
+                        except OSError:
                             pass
         if cli_event:
             cli_event.set()
@@ -729,7 +725,7 @@ class AkitaZmodemMeshCore:
         if self.mesh:
             try:
                 await self.mesh.close()
-            except BaseException:
+            except Exception:
                 pass
 
 # -----------------------------------------------------------------------------
@@ -791,7 +787,7 @@ async def main():
         asyncio.create_task(app.stop())
     try:
         asyncio.get_running_loop().add_signal_handler(signal.SIGINT, sig_handler)
-    except BaseException:
+    except (NotImplementedError, RuntimeError):
         pass
 
     try:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -73,4 +73,87 @@ If your config file specifies serial connection, but you want to use TCP for one
 python akita_zmodem_meshcore.py --mesh-type tcp --tcp-host 192.168.1.50 --tcp-port 6500 send "!NodeAlpha" /myfiles/data.bin
 ```
 
+## Examples: Real MeshCore Setups
+
+Below are example configuration snippets and operational notes for common
+MeshCore setups. These are practical starting points — adapt values to your
+local network and device.
+
+1) Serial-connected MeshCore (USB radio)
+
+```json
+{
+    "mesh_connection_type": "serial",
+    "mesh_serial_port": "/dev/ttyUSB0",
+    "mesh_serial_baud": 115200,
+    "zmodem_app_port": 2001,
+    "mesh_packet_chunk_size": 200
+}
+```
+
+Notes:
+- Ensure the user running the script has read/write access to the serial
+    device (e.g., member of the `dialout` group on many Linux systems).
+- Confirm the device node with `ls -l /dev/ttyUSB0` (or the appropriate
+    device path). If using a USB-to-serial adapter, the device name may differ
+    (e.g., `/dev/ttyACM0`).
+
+2) TCP bridge to a MeshCore daemon (remote or local)
+
+If your MeshCore device is exposed over TCP (for example via a bridge or a
+daemon on a gateway machine), use the TCP connection type:
+
+```json
+{
+    "mesh_connection_type": "tcp",
+    "mesh_tcp_host": "192.168.1.100",
+    "mesh_tcp_port": 4403,
+    "zmodem_app_port": 2001,
+    "mesh_packet_chunk_size": 200
+}
+```
+
+Notes:
+- Make sure the host/port are reachable from the machine running
+    `akita_zmodem_meshcore.py` (test with `nc`/`telnet` or `ss`/`netcat`).
+- The MeshCore Python client (the library that exposes `MeshCore.create_tcp`)
+    must speak the same protocol as the remote service.
+
+3) Example `systemd` unit (daemon mode)
+
+Create `/etc/systemd/system/akita-zmodem.service`:
+
+```ini
+[Unit]
+Description=Akita Zmodem MeshCore daemon
+After=network.target
+
+[Service]
+User=akita
+Group=akita
+WorkingDirectory=/opt/akita/akita-zmodem
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/opt/akita/venv/bin/python /opt/akita/akita-zmodem-meshcore/akita_zmodem_meshcore.py
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Adjust `User`, `WorkingDirectory`, and `ExecStart` to match your install. Use
+`sudo systemctl daemon-reload && sudo systemctl enable --now akita-zmodem` to
+start and enable the service.
+
+4) Troubleshooting
+
+- Serial permission denied: ensure the running user belongs to the group that
+    owns the serial device (e.g., `sudo usermod -aG dialout $USER`).
+- Wrong device: check dmesg output after plugging the radio to find the
+    correct `/dev/tty*` node.
+- TCP connection refused: verify the bridge/daemon is listening on the given
+    host/port and there are no firewall rules blocking access.
+- Fragmentation or errors: reduce `mesh_packet_chunk_size` to accommodate a
+    smaller MTU on your radio link; conservative defaults are 200 bytes.
+
+
 This command will attempt to connect via TCP to 192.168.1.50 on port 6500, overriding any serial settings in `akita_zmodem_meshcore_config.json` for this specific execution.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -140,6 +140,54 @@ The utility will attempt to stop the transfer and clean up associated resources.
 
 ---
 
+## Development & Testing
+
+This project includes a fast unit test suite that runs locally and in CI. To run
+the tests locally, create and activate a virtual environment, install the
+development requirements and run `pytest`:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements-dev.txt
+pytest -v
+```
+
+The `requirements-dev.txt` includes `pytest-asyncio` and `pytest-timeout` to
+support async tests and to prevent hanging tests in CI. Use `--timeout=<sec>`
+to override the default per-test timeout when needed.
+
+## Examples: MeshCore Connection & Setup
+
+This section gives concrete examples for common deployment scenarios.
+
+Serial (USB radio)
+
+```bash
+# Use the system config file or override on the CLI:
+python akita_zmodem_meshcore.py --mesh-type serial --serial-port /dev/ttyUSB0 --serial-baud 115200
+```
+
+Tips:
+- If you get `PermissionError: [Errno 13]`, add your user to the `dialout`
+  group on Linux and re-login (`sudo usermod -aG dialout $USER`).
+- Check `dmesg` after plugging the radio to discover the device node.
+
+TCP bridge
+
+```bash
+# When using a remote MeshCore TCP bridge
+python akita_zmodem_meshcore.py --mesh-type tcp --tcp-host 192.168.1.50 --tcp-port 4403
+```
+
+Tips:
+- Validate connectivity with `nc -vz 192.168.1.50 4403`.
+- Ensure any MeshCore daemon on the remote host speaks the expected
+  protocol for the Python MeshCore client used.
+
+
+
 ## Notes on Operation
 
 - **Node IDs**: The `<destination_node_id>` used in the `send` command must be a valid identifier recognized by your MeshCore setup (e.g. `!aabbccdd`, public key, or name).

--- a/python-lint.yml
+++ b/python-lint.yml
@@ -20,4 +20,4 @@ jobs:
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings.
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistic
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-asyncio
+pytest-timeout

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -48,15 +48,23 @@ class MockSender:
 
 
 class MockReceiver:
-    def __init__(self, fobj):
-        self.fobj = fobj
+    def __init__(self, fobj_or_path):
+        if isinstance(fobj_or_path, str):
+            self.filepath = fobj_or_path
+            self.fobj = open(fobj_or_path, 'wb')
+        else:
+            self.filepath = None
+            self.fobj = fobj_or_path
         self._finished = False
 
     def receive(self, data):
-        # append bytes to file
-        if data:
+        if data and self.fobj:
             self.fobj.write(data)
         self._finished = True
+        if self.fobj:
+            self.fobj.close()
+            self.fobj = None
+        return b""
 
     def is_finished(self):
         return self._finished

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,4 +1,4 @@
-import time
+
 
 class MockCommands:
     def __init__(self):

--- a/tests/test_edgecases.py
+++ b/tests/test_edgecases.py
@@ -1,5 +1,3 @@
-import os
-import asyncio
 import pytest
 
 from akita_zmodem_meshcore import AkitaZmodemMeshCore, _safe_extract_zip
@@ -25,7 +23,8 @@ def test_validate_config_types(tmp_path):
 
 
 def test_safe_extract_zip_memory(tmp_path):
-    # a large zip with many entries should still be handled; just ensure no crash
+    # a large zip with many entries should still be handled; just ensure no
+    # crash
     zip_path = tmp_path / "many.zip"
     import zipfile
     with zipfile.ZipFile(str(zip_path), 'w') as z:
@@ -36,6 +35,7 @@ def test_safe_extract_zip_memory(tmp_path):
     _safe_extract_zip(str(zip_path), str(out))
     assert (out / 'file999.txt').exists()
 
+
 @pytest.mark.asyncio
 async def test_handle_zmodem_data_open_failure(tmp_path, monkeypatch):
     # Simulate failing to open file by making path a directory
@@ -45,6 +45,7 @@ async def test_handle_zmodem_data_open_failure(tmp_path, monkeypatch):
     tid = await app.receive_file(str(tmp_path), overwrite=True)
     # craft a fake payload that _handle_zmodem_data will accept
     # monkeypatch zmodem.Receiver to simple object
+
     class DummyRecv:
         def __init__(self, f): pass
         def receive(self, data): return b''
@@ -69,9 +70,11 @@ async def test_send_directory_skips_symlinks(tmp_path):
     app.mesh = object()
     # monkeypatch send_file to capture path of zip created
     called = {}
+
     async def fake_send(dest, path, cli_event=None):
         called['zip'] = path
-        if cli_event: cli_event.set()
+        if cli_event:
+            cli_event.set()
         return 1
     app.send_file = fake_send
     await app.send_directory('peer', str(d), None, cleanup=False)

--- a/tests/test_edgecases.py
+++ b/tests/test_edgecases.py
@@ -47,7 +47,8 @@ async def test_handle_zmodem_data_open_failure(tmp_path, monkeypatch):
     # monkeypatch zmodem.Receiver to simple object
 
     class DummyRecv:
-        def __init__(self, f): pass
+        def __init__(self, f):
+            raise IsADirectoryError(f"Is a directory: '{f}'")
         def receive(self, data): return b''
         def is_finished(self): return False
     monkeypatch.setattr('zmodem.Receiver', DummyRecv)

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -34,7 +34,9 @@ def setup_env(tmp_path, monkeypatch):
         f.write(b"hello world")
 
     # Monkeypatch meshcore and zmodem modules
-    mock_mesh_mod = types.SimpleNamespace(MeshCore=MockMesh, EventType=types.SimpleNamespace(CONTACT_MSG_RECV=1, ERROR=2))
+    mock_mesh_mod = types.SimpleNamespace(
+        MeshCore=MockMesh, EventType=types.SimpleNamespace(
+            CONTACT_MSG_RECV=1, ERROR=2))
     monkeypatch.setitem(sys.modules, 'meshcore', mock_mesh_mod)
 
     # zmodem module
@@ -46,7 +48,9 @@ def setup_env(tmp_path, monkeypatch):
     def mock_receiver_factory(fobj):
         return MockReceiver(fobj)
 
-    mock_zmod = types.SimpleNamespace(Sender=mock_sender_factory, Receiver=mock_receiver_factory)
+    mock_zmod = types.SimpleNamespace(
+        Sender=mock_sender_factory,
+        Receiver=mock_receiver_factory)
     monkeypatch.setitem(sys.modules, 'zmodem', mock_zmod)
 
     yield
@@ -184,7 +188,6 @@ def test_configuration_file_override(tmp_path):
     assert app.zmodem_app_port == 54321
 
 
-
 def _simulate_zmodem_exchange(sender, receiver):
     """Helper loop to exchange packets until both sides are finished."""
     # both sides may generate responses that need to be fed back
@@ -210,8 +213,10 @@ def test_zmodem_basic_roundtrip(tmp_path):
     # open file objects
     # import the built-in implementation directly (autouse monkeypatch
     # earlier replaces "zmodem" with a mock for the CLI tests)
-    import importlib.util, os
-    spec = importlib.util.spec_from_file_location('builtin_zmodem', os.path.join(os.getcwd(), 'zmodem.py'))
+    import importlib.util
+    import os
+    spec = importlib.util.spec_from_file_location(
+        'builtin_zmodem', os.path.join(os.getcwd(), 'zmodem.py'))
     zm = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(zm)
     Sender, Receiver = zm.Sender, zm.Receiver
@@ -228,15 +233,17 @@ def test_zmodem_resume(tmp_path):
     dst = tmp_path / "recv2.bin"
     original = b"0123456789" * 1000
     # write first half
-    first_half = original[:len(original)//2]
+    first_half = original[:len(original) // 2]
     with open(dst, "wb") as f:
         f.write(first_half)
 
     # now run protocol again; sender must resume
     src = tmp_path / "orig2.bin"
     src.write_bytes(original)
-    import importlib.util, os
-    spec = importlib.util.spec_from_file_location('builtin_zmodem', os.path.join(os.getcwd(), 'zmodem.py'))
+    import importlib.util
+    import os
+    spec = importlib.util.spec_from_file_location(
+        'builtin_zmodem', os.path.join(os.getcwd(), 'zmodem.py'))
     zm = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(zm)
     Sender, Receiver = zm.Sender, zm.Receiver
@@ -252,7 +259,7 @@ def test_zmodem_resume(tmp_path):
 @pytest.mark.asyncio
 async def test_end_to_end_app_transfer(tmp_path):
     # build two apps with a simple in-memory mesh linking them
-    from akita_zmodem_meshcore import AkitaZmodemMeshCore, EventType
+    from akita_zmodem_meshcore import EventType
     import types
 
     class PairMesh:
@@ -260,23 +267,34 @@ async def test_end_to_end_app_transfer(tmp_path):
             self.commands = self
             self.subscriptions = {}
             self.other = None
+
         async def send_msg(self, destination, payload):
             # debug
             print(f"[PairMesh] sending {len(payload)} bytes to {destination}")
             if self.other:
-                ev = types.SimpleNamespace(payload={"decoded": {"payload": payload}, "from": "peer"})
-                for cb in self.other.subscriptions.get(EventType.CONTACT_MSG_RECV, []):
+                ev = types.SimpleNamespace(
+                    payload={
+                        "decoded": {
+                            "payload": payload},
+                        "from": "peer"})
+                for cb in self.other.subscriptions.get(
+                        EventType.CONTACT_MSG_RECV, []):
                     await cb(ev)
+
         def subscribe(self, event, callback):
             self.subscriptions.setdefault(event, []).append(callback)
+
         async def close(self):
             return True
 
     # make sure the application imports the real zmodem implementation
-    import importlib, sys, os
+    import importlib
+    import sys
+    import os
     if 'zmodem' in sys.modules:
         del sys.modules['zmodem']
-    spec = importlib.util.spec_from_file_location('zmodem', os.path.join(os.getcwd(), 'zmodem.py'))
+    spec = importlib.util.spec_from_file_location(
+        'zmodem', os.path.join(os.getcwd(), 'zmodem.py'))
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     sys.modules['zmodem'] = module
@@ -289,8 +307,10 @@ async def test_end_to_end_app_transfer(tmp_path):
     app2 = akita_zmodem_meshcore.AkitaZmodemMeshCore()
     print("app1 mesh_packet_chunk_size", app1.mesh_packet_chunk_size)
     print("app2 mesh_packet_chunk_size", app2.mesh_packet_chunk_size)
-    m1 = PairMesh(); m2 = PairMesh()
-    m1.other = m2; m2.other = m1
+    m1 = PairMesh()
+    m2 = PairMesh()
+    m1.other = m2
+    m2.other = m1
     app1.mesh = m1
     app2.mesh = m2
     # manually register callbacks normally done in _connect_mesh
@@ -314,10 +334,10 @@ async def test_end_to_end_app_transfer(tmp_path):
     asyncio.create_task(app2._timeout_check())
 
     cli_event2 = asyncio.Event()
-    tid2 = await app2.receive_file(str(dest), overwrite=True, cli_event=cli_event2)
+    await app2.receive_file(str(dest), overwrite=True, cli_event=cli_event2)
 
     cli_event1 = asyncio.Event()
-    tid1 = await app1.send_file('peer', str(src), cli_event1)
+    await app1.send_file('peer', str(src), cli_event1)
 
     await asyncio.wait_for(cli_event1.wait(), timeout=5.0)
     await asyncio.wait_for(cli_event2.wait(), timeout=5.0)

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -53,6 +53,11 @@ def setup_env(tmp_path, monkeypatch):
         Receiver=mock_receiver_factory)
     monkeypatch.setitem(sys.modules, 'zmodem', mock_zmod)
 
+    # Also patch the already-imported reference in akita_zmodem_meshcore so
+    # that calls like ``zmodem.Sender(...)`` inside the module use the mock.
+    import akita_zmodem_meshcore
+    monkeypatch.setattr(akita_zmodem_meshcore, 'zmodem', mock_zmod)
+
     yield
 
     # teardown

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -1,4 +1,5 @@
 ﻿import asyncio
+import io
 import os
 import shutil
 import sys
@@ -116,6 +117,110 @@ async def test_send_file_succeeds(monkeypatch, tmp_path):
     await asyncio.wait_for(cli_event.wait(), timeout=5.0)
 
     # transfer should be removed from transfers
+    assert tid not in app.transfers
+
+
+@pytest.mark.asyncio
+async def test_send_file_rejects_empty_destination(tmp_path):
+    from akita_zmodem_meshcore import AkitaZmodemMeshCore
+
+    fp = tmp_path / "small.bin"
+    fp.write_bytes(b"0123456789")
+
+    app = AkitaZmodemMeshCore()
+    app.mesh = MockMesh()
+
+    cli_event = asyncio.Event()
+    tid = await app.send_file('', str(fp), cli_event)
+
+    assert tid is None
+    assert cli_event.is_set()
+    assert app.mesh.commands.sent == []
+
+
+@pytest.mark.asyncio
+async def test_send_file_chunks_use_destination_and_only_prefix_header(monkeypatch, tmp_path):
+    import akita_zmodem_meshcore
+    from akita_zmodem_meshcore import AkitaZmodemMeshCore, APP_PORT_HEADER_FORMAT
+
+    packet = b"ABCDEFGHIJKL"
+    fp = tmp_path / "small.bin"
+    fp.write_bytes(b"placeholder")
+
+    def sender_factory(fobj, *args, **kwargs):
+        sender = MockSender(fobj, packets=[packet])
+        sender.state = 'mock-sending'
+        return sender
+
+    mock_zmod = types.SimpleNamespace(
+        Sender=sender_factory,
+        Receiver=MockReceiver)
+    monkeypatch.setattr(akita_zmodem_meshcore, 'zmodem', mock_zmod)
+
+    app = AkitaZmodemMeshCore()
+    app.mesh = MockMesh()
+    app.mesh_packet_chunk_size = 6
+    app.tx_delay_s = 0
+
+    cli_event = asyncio.Event()
+    tid = await app.send_file('destnode', str(fp), cli_event)
+
+    assert tid is not None
+    await asyncio.wait_for(cli_event.wait(), timeout=5.0)
+
+    header = struct.pack(APP_PORT_HEADER_FORMAT, app.zmodem_app_port)
+    max_piece = app.mesh_packet_chunk_size - len(header)
+    expected = [
+        ('destnode', header + packet[i:i + max_piece])
+        for i in range(0, len(packet), max_piece)
+    ]
+
+    assert app.mesh.commands.sent == expected
+    assert tid not in app.transfers
+
+
+@pytest.mark.asyncio
+async def test_receive_handler_replies_unicast_to_source(monkeypatch, tmp_path):
+    import akita_zmodem_meshcore
+    from akita_zmodem_meshcore import AkitaZmodemMeshCore, APP_PORT_HEADER_FORMAT
+
+    response = b"ACKDATA"
+
+    class ReplyingReceiver:
+        def __init__(self, fobj_or_path):
+            if isinstance(fobj_or_path, str):
+                self.fobj = open(fobj_or_path, 'wb')
+            else:
+                self.fobj = fobj_or_path
+            self._finished = False
+            self.state = 'mock-receiving'
+
+        def receive(self, data):
+            if self.fobj:
+                self.fobj.write(data)
+            self._finished = True
+            return response
+
+        def is_finished(self):
+            return self._finished
+
+    mock_zmod = types.SimpleNamespace(
+        Sender=MockSender,
+        Receiver=ReplyingReceiver)
+    monkeypatch.setattr(akita_zmodem_meshcore, 'zmodem', mock_zmod)
+
+    app = AkitaZmodemMeshCore()
+    app.mesh = MockMesh()
+
+    dest = tmp_path / "incoming.bin"
+    tid = await app.receive_file(str(dest), overwrite=True)
+
+    assert tid is not None
+
+    await app._handle_zmodem_data('node123', b'MOCKDATA')
+
+    header = struct.pack(APP_PORT_HEADER_FORMAT, app.zmodem_app_port)
+    assert app.mesh.commands.sent == [('node123', header + response)]
     assert tid not in app.transfers
 
 
@@ -259,6 +364,49 @@ def test_zmodem_resume(tmp_path):
         _simulate_zmodem_exchange(s, r)
 
     assert dst.read_bytes() == original
+
+
+def test_zmodem_deframe_rejects_oversized_packet(tmp_path):
+    import importlib.util
+    import os
+
+    spec = importlib.util.spec_from_file_location(
+        'builtin_zmodem', os.path.join(os.getcwd(), 'zmodem.py'))
+    zm = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(zm)
+
+    payload = bytearray(struct.pack("!I", zm.MAX_FRAME_PAYLOAD + 1))
+
+    assert list(zm._deframe(payload)) == []
+    assert payload == bytearray()
+
+
+def test_zmodem_receiver_accepts_nameless_file_object(tmp_path):
+    src = tmp_path / "orig3.bin"
+    data = b"nameless target data" * 64
+    src.write_bytes(data)
+
+    import importlib.util
+    import os
+    spec = importlib.util.spec_from_file_location(
+        'builtin_zmodem', os.path.join(os.getcwd(), 'zmodem.py'))
+    zm = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(zm)
+    Sender, Receiver = zm.Sender, zm.Receiver
+
+    class MemorySink(io.BytesIO):
+        def close(self):
+            self.was_closed = True
+
+    sink = MemorySink()
+    sink.was_closed = False
+
+    with open(src, "rb") as sf:
+        s = Sender(sf, chunk_size=128)
+        r = Receiver(sink)
+        _simulate_zmodem_exchange(s, r)
+
+    assert sink.getvalue() == data
 
 
 @pytest.mark.asyncio

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -409,6 +409,48 @@ def test_zmodem_receiver_accepts_nameless_file_object(tmp_path):
     assert sink.getvalue() == data
 
 
+def test_zmodem_sender_ignores_short_ack_frame(tmp_path):
+    src = tmp_path / "orig4.bin"
+    src.write_bytes(b"sender ack guard")
+
+    import importlib.util
+    import os
+    spec = importlib.util.spec_from_file_location(
+        'builtin_zmodem', os.path.join(os.getcwd(), 'zmodem.py'))
+    zm = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(zm)
+    Sender = zm.Sender
+
+    with open(src, "rb") as sf:
+        sender = Sender(sf, chunk_size=128)
+        response = sender.receive(zm._frame(zm._ACK + b'\x00'))
+
+    assert response == b""
+    assert sender.state == 'init'
+
+
+def test_zmodem_receiver_ignores_malformed_frames():
+    import importlib.util
+    import os
+
+    spec = importlib.util.spec_from_file_location(
+        'builtin_zmodem', os.path.join(os.getcwd(), 'zmodem.py'))
+    zm = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(zm)
+    Receiver = zm.Receiver
+
+    receiver = Receiver(io.BytesIO())
+
+    short_start = zm._frame(zm._START + b'\x00')
+    assert receiver.receive(short_start) == b""
+    assert receiver.state == 'waiting'
+
+    receiver.state = 'receiving'
+    short_data = zm._frame(zm._DATA + b'\x00')
+    assert receiver.receive(short_data) == b""
+    assert receiver.offset == 0
+
+
 @pytest.mark.asyncio
 async def test_end_to_end_app_transfer(tmp_path):
     # build two apps with a simple in-memory mesh linking them

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,4 @@
 import asyncio
-import os
-import tempfile
 import zipfile
 import pytest
 
@@ -14,8 +12,8 @@ async def test_calculate_md5_runs_in_thread(tmp_path):
     data = b"abc123" * 10
     p.write_bytes(data)
 
-    # run calculate_md5 in a background thread via asyncio.to_thread and ensure result matches
-    loop = asyncio.get_running_loop()
+    # run calculate_md5 in a background thread via asyncio.to_thread and
+    # ensure result matches
     md = await asyncio.to_thread(calculate_md5, str(p))
 
     # verify known md5

--- a/tests/tmp_test_dir/file1.txt
+++ b/tests/tmp_test_dir/file1.txt
@@ -1,1 +1,0 @@
-hello world

--- a/zmodem.py
+++ b/zmodem.py
@@ -27,6 +27,7 @@ _END = b'E'
 
 # framing helpers: length prefix (uint32) + payload + crc32
 
+
 def _frame(payload: bytes) -> bytes:
     length = struct.pack("!I", len(payload))
     crc = struct.pack("!I", zlib.crc32(payload) & 0xFFFFFFFF)
@@ -44,7 +45,7 @@ def _deframe(buffer: bytearray):
         start = 4
         end = 4 + length
         payload = bytes(buffer[start:end])
-        crc_expected = struct.unpack("!I", buffer[end:end+4])[0]
+        crc_expected = struct.unpack("!I", buffer[end:end + 4])[0]
         crc_actual = zlib.crc32(payload) & 0xFFFFFFFF
         if crc_actual != crc_expected:
             # drop corrupted packet and continue; log for diagnostics
@@ -75,7 +76,8 @@ class Sender:
             return self._queue.pop(0)
         if self.state == 'init':
             # send START header
-            payload = _START + struct.pack("!H", len(self.filename)) + self.filename.encode('utf-8')
+            payload = _START + \
+                struct.pack("!H", len(self.filename)) + self.filename.encode('utf-8')
             payload += struct.pack("!Q", self.filesize)
             self._queue.append(_frame(payload))
             self.state = 'waiting_ack'
@@ -175,8 +177,8 @@ class Receiver:
             tp = payload[:1]
             if tp == _START:
                 name_len = struct.unpack("!H", payload[1:3])[0]
-                name = payload[3:3+name_len].decode('utf-8')
-                size = struct.unpack("!Q", payload[3+name_len:3+name_len+8])[0]
+                size = struct.unpack("!Q",
+                                     payload[3 + name_len:3 + name_len + 8])[0]
                 self.expected_size = size
                 # decide on resume
                 # Determine existing size from filepath (if available) or
@@ -203,21 +205,27 @@ class Receiver:
                     # close any previously opened handle
                     try:
                         if self.fobj:
-                            try: self.fobj.close()
-                            except Exception: pass
+                            try:
+                                self.fobj.close()
+                            except Exception:
+                                pass
                     except Exception:
                         pass
-                    self.fobj = open(target_name, 'ab') if target_name else None
+                    self.fobj = open(
+                        target_name, 'ab') if target_name else None
                     resp = _RESUME + struct.pack("!Q", self.offset)
                 else:
                     # start fresh: open for write (truncate)
                     try:
                         if self.fobj:
-                            try: self.fobj.close()
-                            except Exception: pass
+                            try:
+                                self.fobj.close()
+                            except Exception:
+                                pass
                     except Exception:
                         pass
-                    self.fobj = open(target_name, 'wb') if target_name else None
+                    self.fobj = open(
+                        target_name, 'wb') if target_name else None
                     self.offset = 0
                     resp = _ACK + struct.pack("!Q", self.offset)
                 out += _frame(resp)
@@ -234,7 +242,8 @@ class Receiver:
                     if self.fobj is None:
                         # attempt to open in append mode
                         try:
-                            self.fobj = open(self.filepath, 'ab') if self.filepath else None
+                            self.fobj = open(
+                                self.filepath, 'ab') if self.filepath else None
                         except Exception:
                             # cannot open file; request resume (no change)
                             resp = _RESUME + struct.pack("!Q", self.offset)

--- a/zmodem.py
+++ b/zmodem.py
@@ -18,6 +18,8 @@ import struct
 import zlib
 import logging
 
+MAX_FRAME_PAYLOAD = 1024 * 1024
+
 # packet types
 _START = b'S'      # <filename_len:uint16><filename><filesize:uint64>
 _DATA = b'D'       # <offset:uint64><payload>
@@ -40,6 +42,12 @@ def _deframe(buffer: bytearray):
         if len(buffer) < 4:
             break
         length = struct.unpack("!I", buffer[:4])[0]
+        if length > MAX_FRAME_PAYLOAD:
+            logging.warning(
+                "_deframe: oversized packet length %d, clearing buffer",
+                length)
+            buffer.clear()
+            break
         if len(buffer) < 4 + length + 4:
             break
         start = 4
@@ -202,30 +210,44 @@ class Receiver:
                 if existing and existing < size:
                     # resume: open for append
                     self.offset = existing
-                    # close any previously opened handle
-                    try:
-                        if self.fobj:
-                            try:
-                                self.fobj.close()
-                            except Exception:
-                                pass
-                    except Exception:
-                        pass
-                    self.fobj = open(
-                        target_name, 'ab') if target_name else None
+                    if target_name:
+                        # close any previously opened handle
+                        try:
+                            if self.fobj:
+                                try:
+                                    self.fobj.close()
+                                except Exception:
+                                    pass
+                        except Exception:
+                            pass
+                        self.fobj = open(target_name, 'ab')
+                    elif self.fobj:
+                        try:
+                            self.fobj.seek(self.offset)
+                        except Exception:
+                            pass
                     resp = _RESUME + struct.pack("!Q", self.offset)
                 else:
                     # start fresh: open for write (truncate)
-                    try:
-                        if self.fobj:
-                            try:
-                                self.fobj.close()
-                            except Exception:
-                                pass
-                    except Exception:
-                        pass
-                    self.fobj = open(
-                        target_name, 'wb') if target_name else None
+                    if target_name:
+                        try:
+                            if self.fobj:
+                                try:
+                                    self.fobj.close()
+                                except Exception:
+                                    pass
+                        except Exception:
+                            pass
+                        self.fobj = open(target_name, 'wb')
+                    elif self.fobj:
+                        try:
+                            self.fobj.seek(0)
+                        except Exception:
+                            pass
+                        try:
+                            self.fobj.truncate(0)
+                        except Exception:
+                            pass
                     self.offset = 0
                     resp = _ACK + struct.pack("!Q", self.offset)
                 out += _frame(resp)

--- a/zmodem.py
+++ b/zmodem.py
@@ -119,6 +119,9 @@ class Sender:
         for payload in _deframe(self._inbuf):
             tp = payload[:1]
             if tp == _ACK:
+                if len(payload) < 9:
+                    logging.debug("Sender.receive: short ACK frame ignored")
+                    continue
                 off = struct.unpack("!Q", payload[1:9])[0]
                 # remote acknowledges up to off; update our send offset to match
                 # and position the file accordingly. Clamp to valid range.
@@ -133,6 +136,9 @@ class Sender:
                     pass
                 self.state = 'sending'
             elif tp == _RESUME:
+                if len(payload) < 9:
+                    logging.debug("Sender.receive: short RESUME frame ignored")
+                    continue
                 off = struct.unpack("!Q", payload[1:9])[0]
                 # Clamp resume offset to valid range before seeking
                 if off < 0:
@@ -184,7 +190,13 @@ class Receiver:
         for payload in _deframe(self._inbuf):
             tp = payload[:1]
             if tp == _START:
+                if len(payload) < 11:
+                    logging.debug("Receiver.receive: short START frame ignored")
+                    continue
                 name_len = struct.unpack("!H", payload[1:3])[0]
+                if len(payload) < 3 + name_len + 8:
+                    logging.debug("Receiver.receive: truncated START frame ignored")
+                    continue
                 size = struct.unpack("!Q",
                                      payload[3 + name_len:3 + name_len + 8])[0]
                 self.expected_size = size
@@ -253,6 +265,9 @@ class Receiver:
                 out += _frame(resp)
                 self.state = 'receiving'
             elif tp == _DATA and self.state == 'receiving':
+                if len(payload) < 9:
+                    logging.debug("Receiver.receive: short DATA frame ignored")
+                    continue
                 off = struct.unpack("!Q", payload[1:9])[0]
                 chunk = payload[9:]
                 if off != self.offset:
@@ -262,10 +277,13 @@ class Receiver:
                 else:
                     # Ensure we have an open file handle before writing
                     if self.fobj is None:
+                        if not self.filepath:
+                            resp = _RESUME + struct.pack("!Q", self.offset)
+                            out += _frame(resp)
+                            continue
                         # attempt to open in append mode
                         try:
-                            self.fobj = open(
-                                self.filepath, 'ab') if self.filepath else None
+                            self.fobj = open(self.filepath, 'ab')
                         except Exception:
                             # cannot open file; request resume (no change)
                             resp = _RESUME + struct.pack("!Q", self.offset)


### PR DESCRIPTION
## Summary
This follow-up branch contains the remaining cleanup currently ahead of `origin/main` plus an additional hardening fix for the in-repo ZMODEM implementation.

### Included changes
- documentation and usage/config updates already present on `fix/tests-and-cleanup`
- test and mock cleanup already present on `fix/tests-and-cleanup`
- frame-length hardening in `_deframe` to reject oversized payload lengths before the receive buffer can grow without bound
- `Receiver` handling for nameless file-like objects so an in-memory target is not closed and replaced with `None` during START handling
- regression tests for:
  - explicit unicast send and reply behavior in the MeshCore transfer path
  - oversized framed payload rejection
  - nameless file-like receiver support

## Context
PR #3 is the line that fixed the public-channel flooding behavior later reported in #4 and #5. This PR is a follow-up and should not change that fix status. It carries the remaining cleanup on this branch and addresses protocol-hardening concerns that were still worth landing afterward.

## Validation
- `./.venv/bin/python -m pytest -q`
- `20 passed`

## Notes
- branch diff vs `origin/main`: 12 files changed, 641 insertions, 145 deletions
- key hardening points are in `zmodem.py` and `tests/test_transfers.py`
